### PR TITLE
Changed Preset names to correspond with application

### DIFF
--- a/Source/LRPlugin/MIDI2LR.lrdevplugin/BCF2000.txt
+++ b/Source/LRPlugin/MIDI2LR.lrdevplugin/BCF2000.txt
@@ -1,6 +1,6 @@
-﻿$rev F1 ; Firmware 1.10; BC Manager 2.6.0
+$rev F1 ; Firmware 1.10; BC Manager 2.6.0
 $preset
-  .name 'All Toggles Off         '
+  .name 'MIDI2LR 0.4             '
 ;Designed for MIDI2LR
   .snapshot off
   .request off

--- a/Source/LRPlugin/MIDI2LR.lrdevplugin/BCR2000.txt
+++ b/Source/LRPlugin/MIDI2LR.lrdevplugin/BCR2000.txt
@@ -1,6 +1,6 @@
 $rev R1 ; Firmware 1.10; BC Manager 2.6.0
 $preset
-  .name 'All Toggles Off         '
+  .name 'MIDI2LR 0.4             '
 ;Designed for MIDI2LR
   .snapshot off
   .request off


### PR DESCRIPTION
Should change 0.4 in third line of each preset to correspond to release version. Note that the number of characters between the quote marks should be constant, so if changing number of digits in release number, should add or delete spaces as needed.

I only changed the third line of each preset, but git for some reason treats it as a complete replacement of the prior file.